### PR TITLE
Use localStorage instead of cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@types/chai": "^3.5.2",
     "@types/chai-as-promised": "0.0.30",
-    "@types/js-cookie": "^2.0.28",
     "@types/mocha": "^2.2.41",
     "@types/sinon": "^2.2.2",
     "chai": "^3.0.0",
@@ -44,8 +43,5 @@
     "tslint": "^4.0.0",
     "tslint-microsoft-contrib": "4.0.0",
     "typescript": "^2.3.3"
-  },
-  "dependencies": {
-    "js-cookie": "^2.1.4"
   }
 }

--- a/src/lockal.ts
+++ b/src/lockal.ts
@@ -75,7 +75,8 @@ export class LocalStorageStrategy implements ILockStrategy {
    * @override
    */
   public release(key: string, id: string) {
-    if (this.getHolder(key) === id) {
+    const holder = this.getHolder(key);
+    if (!holder || holder === id) {
       localStorage.removeItem(this.prefix + key);
     }
   }


### PR DESCRIPTION
Decided to go back this way. localStorage has a larger amount of space, and items stored there don't have a bandwidth overhead by being set to the server. The downside is that there's no 'passive' TTL / garbage collection process, so I introduce one that's run automatically when a lock is created (at most every 60 seconds) and also have a timer that releases localStorage locks after their TTL passes.